### PR TITLE
Fix rsync job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ login:
 github_token = ${GITHUB_TOKEN}
 
 rsync:
-	rsync -av --progress --delete ../../urmanac/socryx-topled.arvo.network ./assets/socryx-topled.arvo.network
+	rsync -av --progress --delete ../../urmanac/socryx-topled.arvo.network ./assets/
 
 push:
-	spin registry push ghcr.io/urmanac/urmanac-beta:0.1.0
+	spin registry push ghcr.io/urmanac/urmanac-beta:0.1.1
 
 registry_login:
 	spin registry login ghcr.io -u kingdonb -p $(github_token)

--- a/deploy/spinkube/spinapp.yaml
+++ b/deploy/spinkube/spinapp.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   enableAutoscaling: false
   executor: containerd-shim-spin
-  image: ghcr.io/urmanac/urmanac-beta:0.1.0
+  image: ghcr.io/urmanac/urmanac-beta:0.1.1
   replicas: 1


### PR DESCRIPTION
The build infrastructure/CI pipeline isn't really finished here! But we have a bug already...

The `rsync` command that I used produced a duplicate of everything. We have 99 MB OCI artifact instead of 47 MB. OOPS

Let's fix it quick, before it gets replicated 1000 times by automation 😅 